### PR TITLE
Add option --warn-as-error to promtool

### DIFF
--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -115,6 +115,7 @@ func main() {
 	).Default("5m").Duration()
 
 	experimental := app.Flag("experimental", "Enable experimental commands.").Bool()
+	warnAsError := app.Flag("warn-as-error", "Make all warnings into errors.").Bool()
 
 	sdCheckCmd := checkCmd.Command("service-discovery", "Perform service discovery for the given job name and report the results, including relabeling.")
 	sdConfigFile := sdCheckCmd.Arg("config-file", "The prometheus config file.").Required().ExistingFile()
@@ -372,7 +373,7 @@ func main() {
 		os.Exit(CheckSD(*sdConfigFile, *sdJobName, *sdTimeout, prometheus.DefaultRegisterer))
 
 	case checkConfigCmd.FullCommand():
-		os.Exit(CheckConfig(*agentMode, *checkConfigSyntaxOnly, newConfigLintConfig(*checkConfigLint, *checkConfigLintFatal, *checkConfigIgnoreUnknownFields, model.UTF8Validation, model.Duration(*checkLookbackDelta)), promtoolParser, *configFiles...))
+		os.Exit(CheckConfig(*agentMode, *checkConfigSyntaxOnly, newConfigLintConfig(*checkConfigLint, *checkConfigLintFatal, *checkConfigIgnoreUnknownFields, model.UTF8Validation, model.Duration(*checkLookbackDelta)), *warnAsError, promtoolParser, *configFiles...))
 
 	case checkServerHealthCmd.FullCommand():
 		os.Exit(checkErr(CheckServerStatus(serverURL, checkHealth, httpRoundTripper)))
@@ -384,7 +385,7 @@ func main() {
 		os.Exit(CheckWebConfig(*webConfigFiles...))
 
 	case checkRulesCmd.FullCommand():
-		os.Exit(CheckRules(newRulesLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesIgnoreUnknownFields, model.UTF8Validation), promtoolParser, *ruleFiles...))
+		os.Exit(CheckRules(newRulesLintConfig(*checkRulesLint, *checkRulesLintFatal, *checkRulesIgnoreUnknownFields, model.UTF8Validation), *warnAsError, promtoolParser, *ruleFiles...))
 
 	case checkMetricsCmd.FullCommand():
 		os.Exit(CheckMetrics(*checkMetricsExtended, *checkMetricsLint))
@@ -393,13 +394,13 @@ func main() {
 		os.Exit(PushMetrics(remoteWriteURL, httpRoundTripper, *pushMetricsHeaders, *pushMetricsTimeout, *pushMetricsProtoMsg, *pushMetricsLabels, *metricFiles...))
 
 	case queryInstantCmd.FullCommand():
-		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantExpr, *queryInstantTime, p))
+		os.Exit(QueryInstant(serverURL, httpRoundTripper, *queryInstantExpr, *queryInstantTime, p, *warnAsError))
 
 	case queryRangeCmd.FullCommand():
-		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p))
+		os.Exit(QueryRange(serverURL, httpRoundTripper, *queryRangeHeaders, *queryRangeExpr, *queryRangeBegin, *queryRangeEnd, *queryRangeStep, p, *warnAsError))
 
 	case querySeriesCmd.FullCommand():
-		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p))
+		os.Exit(QuerySeries(serverURL, httpRoundTripper, *querySeriesMatch, *querySeriesBegin, *querySeriesEnd, p, *warnAsError))
 
 	case debugPprofCmd.FullCommand():
 		os.Exit(debugPprof(*debugPprofServer))
@@ -411,7 +412,7 @@ func main() {
 		os.Exit(debugAll(*debugAllServer))
 
 	case queryLabelsCmd.FullCommand():
-		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p))
+		os.Exit(QueryLabels(serverURL, httpRoundTripper, *queryLabelsMatch, *queryLabelsName, *queryLabelsBegin, *queryLabelsEnd, p, *warnAsError))
 
 	case testRulesCmd.FullCommand():
 		results := io.Discard
@@ -598,17 +599,23 @@ func CheckServerStatus(serverURL *url.URL, checkEndpoint string, roundTripper ht
 }
 
 // CheckConfig validates configuration files.
-func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings configLintConfig, p parser.Parser, files ...string) int {
+func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings configLintConfig, warnAsError bool, p parser.Parser, files ...string) int {
 	failed := false
 	hasErrors := false
 
 	for _, f := range files {
-		ruleFiles, scrapeConfigs, err := checkConfig(agentMode, f, checkSyntaxOnly)
+		ruleFiles, scrapeConfigs, warnings, err := checkConfig(agentMode, f, checkSyntaxOnly)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "  FAILED:", err)
 			hasErrors = true
 			failed = true
 		} else {
+			for _, w := range warnings {
+				fmt.Printf("  WARNING: %s\n", w)
+			}
+			if warnAsError && len(warnings) > 0 {
+				failed = true
+			}
 			if len(ruleFiles) > 0 {
 				fmt.Printf("  SUCCESS: %d rule files found\n", len(ruleFiles))
 			}
@@ -624,7 +631,7 @@ func CheckConfig(agentMode, checkSyntaxOnly bool, lintSettings configLintConfig,
 			hasErrors = hasErrors || rulesHaveErrors
 		}
 	}
-	if failed && hasErrors {
+	if failed && (hasErrors || warnAsError) {
 		return failureExitCode
 	}
 	if failed && lintSettings.fatal {
@@ -660,12 +667,12 @@ func checkFileExists(fn string) error {
 	return err
 }
 
-func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]string, []*config.ScrapeConfig, error) {
+func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]string, []*config.ScrapeConfig, []string, error) {
 	fmt.Println("Checking", filename)
 
 	cfg, err := config.LoadFile(filename, agentMode, promslog.NewNopLogger())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var ruleFiles []string
@@ -673,15 +680,15 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 		for _, rf := range cfg.RuleFiles {
 			rfs, err := filepath.Glob(rf)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			// If an explicit file was given, error if it is not accessible.
 			if !strings.Contains(rf, "*") {
 				if len(rfs) == 0 {
-					return nil, nil, fmt.Errorf("%q does not point to an existing file", rf)
+					return nil, nil, nil, fmt.Errorf("%q does not point to an existing file", rf)
 				}
 				if err := checkFileExists(rfs[0]); err != nil {
-					return nil, nil, fmt.Errorf("error checking rule file %q: %w", rfs[0], err)
+					return nil, nil, nil, fmt.Errorf("error checking rule file %q: %w", rfs[0], err)
 				}
 			}
 			ruleFiles = append(ruleFiles, rfs...)
@@ -695,26 +702,27 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 		var err error
 		scfgs, err = cfg.GetScrapeConfigs()
 		if err != nil {
-			return nil, nil, fmt.Errorf("error loading scrape configs: %w", err)
+			return nil, nil, nil, fmt.Errorf("error loading scrape configs: %w", err)
 		}
 	}
 
+	var warnings []string
 	for _, scfg := range scfgs {
 		if !checkSyntaxOnly && scfg.HTTPClientConfig.Authorization != nil {
 			if err := checkFileExists(scfg.HTTPClientConfig.Authorization.CredentialsFile); err != nil {
-				return nil, nil, fmt.Errorf("error checking authorization credentials or bearer token file %q: %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
+				return nil, nil, nil, fmt.Errorf("error checking authorization credentials or bearer token file %q: %w", scfg.HTTPClientConfig.Authorization.CredentialsFile, err)
 			}
 		}
 
 		if err := checkTLSConfig(scfg.HTTPClientConfig.TLSConfig, checkSyntaxOnly); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		for _, c := range scfg.ServiceDiscoveryConfigs {
 			switch c := c.(type) {
 			case *kubernetes.SDConfig:
 				if err := checkTLSConfig(c.HTTPClientConfig.TLSConfig, checkSyntaxOnly); err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 			case *file.SDConfig:
 				if checkSyntaxOnly {
@@ -723,26 +731,26 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 				for _, file := range c.Files {
 					files, err := filepath.Glob(file)
 					if err != nil {
-						return nil, nil, err
+						return nil, nil, nil, err
 					}
 					if len(files) != 0 {
 						for _, f := range files {
 							var targetGroups []*targetgroup.Group
 							targetGroups, err = checkSDFile(f)
 							if err != nil {
-								return nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
+								return nil, nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
 							}
 							if err := checkTargetGroupsForScrapeConfig(targetGroups, scfg); err != nil {
-								return nil, nil, err
+								return nil, nil, nil, err
 							}
 						}
 						continue
 					}
-					fmt.Printf("  WARNING: file %q for file_sd in scrape job %q does not exist\n", file, scfg.JobName)
+					warnings = append(warnings, fmt.Sprintf("file %q for file_sd in scrape job %q does not exist", file, scfg.JobName))
 				}
 			case discovery.StaticConfig:
 				if err := checkTargetGroupsForScrapeConfig(c, scfg); err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 			}
 		}
@@ -759,32 +767,32 @@ func checkConfig(agentMode bool, filename string, checkSyntaxOnly bool) ([]strin
 				for _, file := range c.Files {
 					files, err := filepath.Glob(file)
 					if err != nil {
-						return nil, nil, err
+						return nil, nil, nil, err
 					}
 					if len(files) != 0 {
 						for _, f := range files {
 							var targetGroups []*targetgroup.Group
 							targetGroups, err = checkSDFile(f)
 							if err != nil {
-								return nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
+								return nil, nil, nil, fmt.Errorf("checking SD file %q: %w", file, err)
 							}
 
 							if err := checkTargetGroupsForAlertmanager(targetGroups, amcfg); err != nil {
-								return nil, nil, err
+								return nil, nil, nil, err
 							}
 						}
 						continue
 					}
-					fmt.Printf("  WARNING: file %q for file_sd in alertmanager config does not exist\n", file)
+					warnings = append(warnings, fmt.Sprintf("file %q for file_sd in alertmanager config does not exist", file))
 				}
 			case discovery.StaticConfig:
 				if err := checkTargetGroupsForAlertmanager(c, amcfg); err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 			}
 		}
 	}
-	return ruleFiles, scfgs, nil
+	return ruleFiles, scfgs, warnings, nil
 }
 
 func checkTLSConfig(tlsConfig promconfig.TLSConfig, checkSyntaxOnly bool) error {
@@ -846,7 +854,7 @@ func checkSDFile(filename string) ([]*targetgroup.Group, error) {
 }
 
 // CheckRules validates rule files.
-func CheckRules(ls rulesLintConfig, p parser.Parser, files ...string) int {
+func CheckRules(ls rulesLintConfig, warnAsError bool, p parser.Parser, files ...string) int {
 	failed := false
 	hasErrors := false
 	if len(files) == 0 {
@@ -855,7 +863,7 @@ func CheckRules(ls rulesLintConfig, p parser.Parser, files ...string) int {
 		failed, hasErrors = checkRules(files, ls, p)
 	}
 
-	if failed && hasErrors {
+	if failed && (hasErrors || warnAsError) {
 		return failureExitCode
 	}
 	if failed && ls.fatal {

--- a/cmd/promtool/main_test.go
+++ b/cmd/promtool/main_test.go
@@ -71,14 +71,14 @@ func TestQueryRange(t *testing.T) {
 	require.NoError(t, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 0, p)
+	exitCode := QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 0, p, false)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
 	require.Equal(t, "1", form.Get("step"))
 	require.Equal(t, 0, exitCode)
 
-	exitCode = QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 10*time.Millisecond, p)
+	exitCode = QueryRange(urlObject, http.DefaultTransport, map[string]string{}, "up", "0", "300", 10*time.Millisecond, p, false)
 	require.Equal(t, "/api/v1/query_range", getRequest().URL.Path)
 	form = getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
@@ -95,7 +95,7 @@ func TestQueryInstant(t *testing.T) {
 	require.NoError(t, err)
 
 	p := &promqlPrinter{}
-	exitCode := QueryInstant(urlObject, http.DefaultTransport, "up", "300", p)
+	exitCode := QueryInstant(urlObject, http.DefaultTransport, "up", "300", p, false)
 	require.Equal(t, "/api/v1/query", getRequest().URL.Path)
 	form := getRequest().Form
 	require.Equal(t, "up", form.Get("query"))
@@ -236,7 +236,7 @@ func TestCheckTargetConfig(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := checkConfig(false, "testdata/"+test.file, false)
+			_, _, _, err := checkConfig(false, "testdata/"+test.file, false)
 			if test.err != "" {
 				require.EqualErrorf(t, err, test.err, "Expected error %q, got %q", test.err, err.Error())
 				return
@@ -321,7 +321,7 @@ func TestCheckConfigSyntax(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := checkConfig(false, "testdata/"+test.file, test.syntaxOnly)
+			_, _, _, err := checkConfig(false, "testdata/"+test.file, test.syntaxOnly)
 			expectedErrMsg := test.err
 			if strings.Contains(runtime.GOOS, "windows") {
 				expectedErrMsg = test.errWindows
@@ -357,7 +357,7 @@ func TestAuthorizationConfig(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := checkConfig(false, "testdata/"+test.file, false)
+			_, _, _, err := checkConfig(false, "testdata/"+test.file, false)
 			if test.err != "" {
 				require.ErrorContains(t, err, test.err, "Expected error to contain %q, got %q", test.err, err.Error())
 				return
@@ -603,7 +603,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}))
 		require.Equal(t, successExitCode, exitCode)
 	})
 
@@ -625,7 +625,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}))
 		require.Equal(t, failureExitCode, exitCode)
 	})
 
@@ -647,7 +647,7 @@ func TestCheckRules(t *testing.T) {
 		defer func(v *os.File) { os.Stdin = v }(os.Stdin)
 		os.Stdin = r
 
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), parser.NewParser(parser.Options{}))
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}))
 		require.Equal(t, lintErrExitCode, exitCode)
 	})
 }
@@ -665,19 +665,19 @@ func TestCheckRulesWithFeatureFlag(t *testing.T) {
 func TestCheckRulesWithRuleFiles(t *testing.T) {
 	t.Run("rules-good", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/rules.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}), "./testdata/rules.yml")
 		require.Equal(t, successExitCode, exitCode)
 	})
 
 	t.Run("rules-bad", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/rules-bad.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}), "./testdata/rules-bad.yml")
 		require.Equal(t, failureExitCode, exitCode)
 	})
 
 	t.Run("rules-lint-fatal", func(t *testing.T) {
 		t.Parallel()
-		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), parser.NewParser(parser.Options{}), "./testdata/prometheus-rules.lint.yml")
+		exitCode := CheckRules(newRulesLintConfig(lintOptionDuplicateRules, true, false, model.UTF8Validation), false, parser.NewParser(parser.Options{}), "./testdata/prometheus-rules.lint.yml")
 		require.Equal(t, lintErrExitCode, exitCode)
 	})
 }
@@ -707,23 +707,44 @@ func TestCheckScrapeConfigs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Non-fatal linting.
 			p := parser.NewParser(parser.Options{})
-			code := CheckConfig(false, false, newConfigLintConfig(lintOptionTooLongScrapeInterval, false, false, model.UTF8Validation, tc.lookbackDelta), p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			code := CheckConfig(false, false, newConfigLintConfig(lintOptionTooLongScrapeInterval, false, false, model.UTF8Validation, tc.lookbackDelta), false, p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
 			require.Equal(t, successExitCode, code, "Non-fatal linting should return success")
 			// Fatal linting.
-			code = CheckConfig(false, false, newConfigLintConfig(lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			code = CheckConfig(false, false, newConfigLintConfig(lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), false, p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
 			if tc.expectError {
 				require.Equal(t, lintErrExitCode, code, "Fatal linting should return error")
 			} else {
 				require.Equal(t, successExitCode, code, "Fatal linting should return success when there are no problems")
 			}
 			// Check syntax only, no linting.
-			code = CheckConfig(false, true, newConfigLintConfig(lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			code = CheckConfig(false, true, newConfigLintConfig(lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), false, p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
 			require.Equal(t, successExitCode, code, "Fatal linting should return success when checking syntax only")
 			// Lint option "none" should disable linting.
-			code = CheckConfig(false, false, newConfigLintConfig(lintOptionNone+","+lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+			code = CheckConfig(false, false, newConfigLintConfig(lintOptionNone+","+lintOptionTooLongScrapeInterval, true, false, model.UTF8Validation, tc.lookbackDelta), false, p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
 			require.Equal(t, successExitCode, code, `Fatal linting should return success when lint option "none" is specified`)
 		})
 	}
+}
+
+func TestWarnAsError(t *testing.T) {
+	t.Parallel()
+	p := parser.NewParser(parser.Options{})
+
+	// Without --warn-as-error, missing file_sd files produce a warning but succeed.
+	code := CheckConfig(false, false, newConfigLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation, 0), false, p, "./testdata/config_with_service_discovery_files.yml")
+	require.Equal(t, successExitCode, code, "Missing file_sd files should not fail without --warn-as-error")
+
+	// With --warn-as-error, missing file_sd files cause failure.
+	code = CheckConfig(false, false, newConfigLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation, 0), true, p, "./testdata/config_with_service_discovery_files.yml")
+	require.Equal(t, failureExitCode, code, "Missing file_sd files should fail with --warn-as-error")
+
+	// With --warn-as-error, lint issues also cause failure with exit code 1 (not 3).
+	code = CheckConfig(false, false, newConfigLintConfig(lintOptionTooLongScrapeInterval, false, false, model.UTF8Validation, model.Duration(5*time.Minute)), true, p, "./testdata/prometheus-config.lint.too_long_scrape_interval.yml")
+	require.Equal(t, failureExitCode, code, "Lint issues should fail with exit code 1 when --warn-as-error is set")
+
+	// With --warn-as-error, lint issues in rules also cause failure with exit code 1.
+	code = CheckRules(newRulesLintConfig(lintOptionDuplicateRules, false, false, model.UTF8Validation), true, p, "./testdata/prometheus-rules.lint.yml")
+	require.Equal(t, failureExitCode, code, "Lint rule issues should fail with exit code 1 when --warn-as-error is set")
 }
 
 func TestTSDBDumpCommand(t *testing.T) {

--- a/cmd/promtool/query.go
+++ b/cmd/promtool/query.go
@@ -61,7 +61,7 @@ func newAPI(url *url.URL, roundTripper http.RoundTripper, headers map[string]str
 }
 
 // QueryInstant performs an instant query against a Prometheus server.
-func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime string, p printer) int {
+func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime string, p printer, warnAsError bool) int {
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
@@ -79,10 +79,16 @@ func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime 
 
 	// Run query against client.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Query(ctx, query, eTime) // Ignoring warnings for now.
+	val, warnings, err := api.Query(ctx, query, eTime)
 	cancel()
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, "query warning:", w)
+	}
 	if err != nil {
 		return handleAPIError(err)
+	}
+	if warnAsError && len(warnings) > 0 {
+		return failureExitCode
 	}
 
 	p.printValue(val)
@@ -91,7 +97,7 @@ func QueryInstant(url *url.URL, roundTripper http.RoundTripper, query, evalTime 
 }
 
 // QueryRange performs a range query against a Prometheus server.
-func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, query, start, end string, step time.Duration, p printer) int {
+func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string]string, query, start, end string, step time.Duration, p printer, warnAsError bool) int {
 	api, err := newAPI(url, roundTripper, headers)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
@@ -134,11 +140,16 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 	// Run query against client.
 	r := v1.Range{Start: stime, End: etime, Step: step}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.QueryRange(ctx, query, r) // Ignoring warnings for now.
+	val, warnings, err := api.QueryRange(ctx, query, r)
 	cancel()
-
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, "query warning:", w)
+	}
 	if err != nil {
 		return handleAPIError(err)
+	}
+	if warnAsError && len(warnings) > 0 {
+		return failureExitCode
 	}
 
 	p.printValue(val)
@@ -146,7 +157,7 @@ func QueryRange(url *url.URL, roundTripper http.RoundTripper, headers map[string
 }
 
 // QuerySeries queries for a series against a Prometheus server.
-func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string, start, end string, p printer) int {
+func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string, start, end string, p printer, warnAsError bool) int {
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
@@ -161,11 +172,16 @@ func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string
 
 	// Run query against client.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Series(ctx, matchers, stime, etime) // Ignoring warnings for now.
+	val, warnings, err := api.Series(ctx, matchers, stime, etime)
 	cancel()
-
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, "query warning:", w)
+	}
 	if err != nil {
 		return handleAPIError(err)
+	}
+	if warnAsError && len(warnings) > 0 {
+		return failureExitCode
 	}
 
 	p.printSeries(val)
@@ -173,7 +189,7 @@ func QuerySeries(url *url.URL, roundTripper http.RoundTripper, matchers []string
 }
 
 // QueryLabels queries for label values against a Prometheus server.
-func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string, name, start, end string, p printer) int {
+func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string, name, start, end string, p printer, warnAsError bool) int {
 	api, err := newAPI(url, roundTripper, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error creating API client:", err)
@@ -196,6 +212,9 @@ func QueryLabels(url *url.URL, roundTripper http.RoundTripper, matchers []string
 	}
 	if err != nil {
 		return handleAPIError(err)
+	}
+	if warnAsError && len(warn) > 0 {
+		return failureExitCode
 	}
 
 	p.printLabelValues(val)

--- a/docs/command-line/promtool.md
+++ b/docs/command-line/promtool.md
@@ -12,6 +12,7 @@ Tooling for the Prometheus monitoring system.
 | <code class="text-nowrap">-h</code>, <code class="text-nowrap">--help</code> | Show context-sensitive help (also try --help-long and --help-man). |
 | <code class="text-nowrap">--version</code> | Show application version. |
 | <code class="text-nowrap">--experimental</code> | Enable experimental commands. |
+| <code class="text-nowrap">--warn-as-error</code> | Make all warnings into errors. |
 | <code class="text-nowrap">--enable-feature</code> <code class="text-nowrap">...<code class="text-nowrap"> | Comma separated feature names to enable. Valid options: promql-experimental-functions, promql-delayed-name-removal, promql-duration-expr, promql-extended-range-selectors. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details |
 
 


### PR DESCRIPTION
  cmd/promtool/main.go:
  - Added --warn-as-error global flag to the app
  - Changed checkConfig (inner function) return type to include []string for warnings, replacing the inline fmt.Printf("  WARNING: ...") calls with a collected warnings slice
  - Updated CheckConfig to accept warnAsError bool: prints collected warnings, sets failed=true if warnAsError && len(warnings) > 0, and uses failed && (hasErrors || warnAsError) for exit code logic
  - Updated CheckRules to accept warnAsError bool with the same exit code logic
  - Wired *warnAsError into all relevant switch cases

  cmd/promtool/query.go:
  - Added warnAsError bool parameter to QueryInstant, QueryRange, QuerySeries, and QueryLabels
  - Replaced _ with named warnings variable in QueryInstant, QueryRange, QuerySeries
  - All four query functions now print warnings and return failureExitCode when warnAsError && len(warnings) > 0

  cmd/promtool/main_test.go:
  - Updated all call sites for changed signatures
  - Added TestWarnAsError covering: file_sd warnings, lint warnings in config, and lint warnings in rules

  docs/command-line/promtool.md:
  - Regenerated to include the new --warn-as-error flag

  The flag applies globally to all commands. With --warn-as-error, any warning (missing file_sd files, API query warnings, lint issues) causes exit code
   1 rather than silent success.

<!--
    - Please give your PR a title in the form "area: short description".  For example "tsdb: reduce disk usage by 95%"

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Which issue(s) does the PR fix:
https://github.com/prometheus/prometheus/issues/12499
<!--
If it applies.
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```
